### PR TITLE
Add todo.txt export and auto-sync

### DIFF
--- a/backlog/config.yml
+++ b/backlog/config.yml
@@ -2,7 +2,6 @@ project_name: "taskbridge"
 default_status: "To Do"
 statuses: ["To Do", "In Progress", "Done"]
 labels: []
-milestones: []
 date_format: yyyy-mm-dd
 max_column_width: 20
 default_editor: "vim"
@@ -14,3 +13,4 @@ zero_padded_ids: 2
 bypass_git_hooks: true
 check_active_branches: true
 active_branch_days: 30
+task_prefix: "task"

--- a/backlog/tasks/task-26 - Add-support-to-migrate-tasks-to-a-todo.txt-format.md
+++ b/backlog/tasks/task-26 - Add-support-to-migrate-tasks-to-a-todo.txt-format.md
@@ -1,0 +1,49 @@
+---
+id: TASK-26
+title: Add support to migrate tasks to a todo.txt format
+status: Done
+assignee:
+  - '@iross'
+created_date: '2026-06-15 17:52'
+updated_date: '2026-06-15 18:18'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Maintain a todo.txt file that stays in sync with Todoist tasks. TaskBridge writes and updates this file automatically after any command that changes task state, giving users a portable, app-agnostic snapshot that works with any todo.txt-compatible tool (topydo, todotxt-cli, etc.). A one-time export command is also provided for the initial write or manual refresh.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A `todo_txt_path` setting is configurable via `taskbridge config` (optional; if unset all todo.txt sync is silently skipped)
+- [x] #2 A `taskbridge export todo-txt [OUTPUT_FILE]` command performs a full regeneration of the file from current Todoist state
+- [x] #3 After `task done`, `sync notes`, `sync projects`, and `sync jira`, the configured todo.txt file is automatically regenerated
+- [x] #4 Active tasks are formatted per the todo.txt spec: `(PRIORITY) YYYY-MM-DD content +Project @label due:YYYY-MM-DD`
+- [x] #5 Priority is mapped correctly: Todoist p1 (API priority 4) → `(A)`, p2 → `(B)`, p3 → `(C)`, p4 (API priority 1) → no priority marker
+- [x] #6 Completed tasks are included with an `x YYYY-MM-DD` prefix (completion date)
+- [x] #7 Project name is appended as a `+ProjectName` tag (spaces replaced with underscores)
+- [x] #8 Labels are appended as `@label` context tags
+- [x] #9 Due dates are appended as `due:YYYY-MM-DD` key-value extension fields
+- [x] #10 Task creation date (from `created_at`) is included as the ISO date field after the priority marker
+- [x] #11 Unit tests cover the formatting function with representative cases (all priorities, completed tasks, labels, projects with spaces, due dates)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add `todo_txt_path` to `config.py` with getter/setter; add configuration prompt to `taskbridge config` (or a new `taskbridge config todo-txt` subcommand)
+2. Implement `format_task_as_todo_txt(task: TodoistTask, project_name: str) -> str` helper: map priority int→letter, handle `x YYYY-MM-DD` prefix for completed tasks, sanitize project name, append labels as @tags, append due date as key-value
+3. Implement `write_todo_txt(path: str)` that fetches all tasks (active + recently completed) and projects from the Todoist API, formats each line, and atomically writes the file
+4. Add `export_app` typer sub-app to `main.py` and wire up `taskbridge export todo-txt [OUTPUT_FILE]` to call `write_todo_txt()`
+5. Add a `_sync_todo_txt()` helper that reads `todo_txt_path` from config and calls `write_todo_txt()` if configured; call it at the end of `task_done`, `sync_notes`, `sync_projects`, and `sync_jira`
+6. Write unit tests in `tests/unit/` covering the formatting function; integration path tested via the export command
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented todo.txt export and auto-sync. Added: `format_task_as_todo_txt()` formatter, `write_todo_txt()` atomic file writer, `_fetch_todo_txt_lines()` (fetches active + best-effort completed via filter), `_sync_todo_txt()` silent hook, `taskbridge config todo-txt` command, `taskbridge export todo-txt [OUTPUT_FILE]` command. Hooked sync into task_done, sync_notes, sync_projects, sync_jira. Added `completed_at` field to TodoistTask dataclass. 16 unit tests in tests/unit/test_todo_txt.py cover all formatting cases.
+<!-- SECTION:NOTES:END -->

--- a/src/taskbridge/config.py
+++ b/src/taskbridge/config.py
@@ -182,6 +182,14 @@ class Config:
         except Exception:
             return False
 
+    def get_todo_txt_path(self) -> str | None:
+        """Get path to the todo.txt file for automatic sync."""
+        return self.get("todo_txt_path")
+
+    def set_todo_txt_path(self, path: str | None) -> None:
+        """Set path to the todo.txt file for automatic sync."""
+        self.set("todo_txt_path", path)
+
     def get_obsidian_vault_path(self) -> str | os.PathLike[str]:
         """Get Obsidian vault path."""
         return self.get("obsidian_vault_path")

--- a/src/taskbridge/main.py
+++ b/src/taskbridge/main.py
@@ -12,7 +12,7 @@ import typer
 from .bartib_integration import BartibIntegration
 from .config import config as config_manager
 from .database import TaskTimeTracking, TodoistNoteMapping, db
-from .todoist_api import TodoistAPI
+from .todoist_api import TodoistAPI, TodoistTask
 
 # Main app
 app = typer.Typer(
@@ -29,6 +29,7 @@ map_app = typer.Typer(help="Task-to-note mapping commands")
 sync_app = typer.Typer(help="Synchronization commands")
 time_app = typer.Typer(help="Time tracking commands")
 meeting_app = typer.Typer(help="Meeting time tracking commands")
+export_app = typer.Typer(help="Export commands")
 
 app.add_typer(config_app, name="config")
 app.add_typer(task_app, name="task")
@@ -37,6 +38,7 @@ app.add_typer(map_app, name="map")
 app.add_typer(sync_app, name="sync")
 app.add_typer(time_app, name="time")
 app.add_typer(meeting_app, name="meeting")
+app.add_typer(export_app, name="export")
 
 
 # ============================================================================
@@ -227,6 +229,27 @@ def config_jira():
         typer.echo(f"   Project filter: {', '.join(project_filter)}")
     else:
         typer.echo("   No project filter — all assigned issues will be synced")
+
+
+@config_app.command("todo-txt")
+def config_todo_txt():
+    """Configure the todo.txt file path for automatic sync."""
+    current = config_manager.get_todo_txt_path()
+    if current:
+        typer.echo(f"Current todo.txt path: {current}")
+        if not typer.confirm("Update path?"):
+            return
+    path = typer.prompt("Path for todo.txt file (leave empty to disable)", default="")
+    if not path:
+        config_manager.set_todo_txt_path(None)
+        typer.echo("✅ todo.txt sync disabled")
+        return
+    resolved = str(Path(path).expanduser())
+    if not Path(resolved).parent.exists():
+        typer.echo(f"❌ Directory does not exist: {Path(resolved).parent}")
+        raise typer.Exit(1) from None
+    config_manager.set_todo_txt_path(resolved)
+    typer.echo(f"✅ todo.txt path set to: {resolved}")
 
 
 # ============================================================================
@@ -530,6 +553,7 @@ def task_done(
             typer.echo("\nℹ️  No Obsidian note found for this task")
 
         typer.echo("\n✅ Task completed!")
+        _sync_todo_txt()
 
     except Exception as e:
         typer.echo(f"❌ Error: {e}")
@@ -1292,6 +1316,7 @@ def sync_notes(
         typer.echo(f"✅ Created: {created_count}")
         typer.echo(f"❌ Failed: {failed_count}")
         typer.echo(f"📋 Total: {len(new_tasks)}")
+        _sync_todo_txt()
 
     except Exception as e:
         typer.echo(f"❌ Error: {e}")
@@ -1420,6 +1445,7 @@ def sync_projects(
         typer.echo(f"   ✅ Synced: {synced_count}")
         typer.echo(f"   ❌ Failed: {failed_count}")
         typer.echo(f"   📋 Total: {len(projects_to_sync)}")
+        _sync_todo_txt()
 
     except Exception as e:
         typer.echo(f"❌ Error: {e}")
@@ -1585,6 +1611,107 @@ def sync_jira(
         )
     else:
         typer.echo("✅ Nothing to do.")
+    _sync_todo_txt()
+
+
+# ============================================================================
+# TODO.TXT HELPERS AND EXPORT COMMAND
+# ============================================================================
+
+_PRIORITY_LETTER: dict[int, str] = {4: "A", 3: "B", 2: "C"}
+
+
+def format_task_as_todo_txt(task: TodoistTask, project_name: str, client: str = "") -> str:
+    """Format a Todoist task as a single todo.txt line."""
+    parts: list[str] = []
+
+    if task.is_completed:
+        completion_date = (task.completed_at or "")[:10] or datetime.now().strftime("%Y-%m-%d")
+        parts.append(f"x {completion_date}")
+
+    letter = _PRIORITY_LETTER.get(task.priority)
+    if letter:
+        parts.append(f"({letter})")
+
+    if task.created_at:
+        parts.append(task.created_at[:10])
+
+    parts.append(task.content)
+
+    if project_name:
+        parts.append(f"+{project_name.replace(' ', '_')}")
+
+    for label in task.labels:
+        parts.append(f"@{label}")
+
+    if task.due:
+        due_date = task.due.get("date", "")[:10]
+        if due_date:
+            parts.append(f"due:{due_date}")
+
+    if client:
+        parts.append(f"client:{client}")
+
+    return " ".join(parts)
+
+
+def _fetch_todo_txt_lines() -> list[str]:
+    """Fetch active and completed tasks from Todoist, return as todo.txt lines."""
+    api = TodoistAPI()
+    project_mappings = config_manager.get_todoist_project_mappings()
+    todoist_projects = {p.id: p.name for p in api.get_projects()}
+    tasks = api.get_tasks()
+    completed: list[TodoistTask] = []
+    with contextlib.suppress(Exception):
+        completed = api.get_tasks(filter_query="is:completed")
+
+    lines = []
+    for t in tasks + completed:
+        mapping = project_mappings.get(t.project_id, {})
+        project_name = mapping.get("folder") or todoist_projects.get(t.project_id, "")
+        client = mapping.get("client", "")
+        lines.append(format_task_as_todo_txt(t, project_name, client))
+    return lines
+
+
+def write_todo_txt(path: str) -> None:
+    """Atomically regenerate the todo.txt file from current Todoist state."""
+    lines = _fetch_todo_txt_lines()
+    output = Path(path)
+    tmp = output.parent / f".{output.name}.tmp"
+    tmp.write_text("\n".join(lines) + ("\n" if lines else ""))
+    tmp.replace(output)
+
+
+def _sync_todo_txt() -> None:
+    """Regenerate the configured todo.txt file; silent no-op if unconfigured."""
+    path = config_manager.get_todo_txt_path()
+    if not path:
+        return
+    try:
+        write_todo_txt(path)
+    except Exception as e:
+        typer.echo(f"⚠️  todo.txt sync failed: {e}")
+
+
+@export_app.command("todo-txt")
+def export_todo_txt(
+    output_file: str | None = typer.Argument(None, help="Output file path (stdout if omitted)"),
+):
+    """Export all Todoist tasks to todo.txt format."""
+    if not config_manager.get_todoist_token():
+        typer.echo("❌ Todoist not configured. Run 'taskbridge config todoist' first.")
+        raise typer.Exit(1) from None
+    try:
+        if output_file:
+            write_todo_txt(output_file)
+            typer.echo(f"✅ Exported to {output_file}")
+        else:
+            for line in _fetch_todo_txt_lines():
+                typer.echo(line)
+    except Exception as e:
+        typer.echo(f"❌ Error: {e}")
+        raise typer.Exit(1) from None
 
 
 # ============================================================================

--- a/src/taskbridge/todoist_api.py
+++ b/src/taskbridge/todoist_api.py
@@ -48,6 +48,7 @@ class TodoistTask:
     assignee_id: str | None = None
     assigner_id: str | None = None
     is_completed: bool = False
+    completed_at: str | None = None
 
     def __post_init__(self):
         """Initialize default values for mutable fields."""
@@ -271,6 +272,7 @@ class TodoistAPI:
                         assignee_id=task_data.get("assignee_id"),
                         assigner_id=task_data.get("assigner_id"),
                         is_completed=task_data.get("is_completed", False),
+                        completed_at=task_data.get("completed_at"),
                     )
                 )
 

--- a/tests/unit/test_todo_txt.py
+++ b/tests/unit/test_todo_txt.py
@@ -1,0 +1,120 @@
+"""Unit tests for todo.txt formatting."""
+
+import re
+
+from taskbridge.main import format_task_as_todo_txt
+from taskbridge.todoist_api import TodoistTask
+
+
+def make_task(**kwargs) -> TodoistTask:
+    defaults = {
+        "id": "1",
+        "content": "Buy milk",
+        "description": "",
+        "project_id": "p1",
+        "labels": [],
+        "priority": 1,
+        "due": None,
+        "created_at": "2023-01-15T10:00:00Z",
+        "is_completed": False,
+        "completed_at": None,
+    }
+    defaults.update(kwargs)
+    return TodoistTask(**defaults)
+
+
+class TestFormatTaskAsTodoTxt:
+    def test_active_no_priority(self):
+        result = format_task_as_todo_txt(make_task(priority=1), "Groceries")
+        assert result == "2023-01-15 Buy milk +Groceries"
+
+    def test_priority_a(self):
+        result = format_task_as_todo_txt(make_task(priority=4), "Work")
+        assert result.startswith("(A) 2023-01-15 Buy milk")
+
+    def test_priority_b(self):
+        result = format_task_as_todo_txt(make_task(priority=3), "")
+        assert "(B)" in result
+
+    def test_priority_c(self):
+        result = format_task_as_todo_txt(make_task(priority=2), "")
+        assert "(C)" in result
+
+    def test_no_project_omits_plus_tag(self):
+        result = format_task_as_todo_txt(make_task(), "")
+        assert "+" not in result
+
+    def test_project_spaces_replaced_with_underscores(self):
+        result = format_task_as_todo_txt(make_task(), "My Project")
+        assert "+My_Project" in result
+
+    def test_labels_as_at_contexts(self):
+        result = format_task_as_todo_txt(make_task(labels=["errands", "home"]), "")
+        assert "@errands" in result
+        assert "@home" in result
+
+    def test_due_date_extension(self):
+        result = format_task_as_todo_txt(make_task(due={"date": "2023-02-01"}), "")
+        assert "due:2023-02-01" in result
+
+    def test_due_date_datetime_truncated_to_date(self):
+        result = format_task_as_todo_txt(make_task(due={"date": "2023-02-01T09:00:00"}), "")
+        assert "due:2023-02-01" in result
+
+    def test_no_due_date_omits_extension(self):
+        result = format_task_as_todo_txt(make_task(due=None), "")
+        assert "due:" not in result
+
+    def test_creation_date_included(self):
+        result = format_task_as_todo_txt(make_task(created_at="2023-01-15T10:00:00Z"), "")
+        assert "2023-01-15" in result
+
+    def test_no_created_at_omits_date(self):
+        result = format_task_as_todo_txt(make_task(created_at=""), "")
+        assert not re.search(r"\d{4}-\d{2}-\d{2}", result)
+
+    def test_completed_task_x_prefix_with_completion_date(self):
+        result = format_task_as_todo_txt(
+            make_task(is_completed=True, completed_at="2023-01-20T12:00:00Z"), ""
+        )
+        assert result.startswith("x 2023-01-20")
+
+    def test_completed_task_no_completed_at_uses_today(self):
+        result = format_task_as_todo_txt(make_task(is_completed=True, completed_at=None), "")
+        assert re.match(r"x \d{4}-\d{2}-\d{2}", result)
+
+    def test_field_ordering_priority_date_content_project_label_due(self):
+        task = make_task(priority=4, labels=["home"], due={"date": "2023-02-01"})
+        result = format_task_as_todo_txt(task, "Work")
+        parts = result.split()
+        assert parts[0] == "(A)"
+        assert parts[1] == "2023-01-15"
+        assert parts[2] == "Buy"
+        assert parts[3] == "milk"
+        assert "+Work" in parts
+        assert "@home" in parts
+        assert "due:2023-02-01" in parts
+        # Project and label come after content, due comes last
+        content_idx = result.index("Buy milk")
+        assert result.index("+Work") > content_idx
+        assert result.index("due:2023-02-01") > result.index("+Work")
+
+    def test_completed_task_preserves_priority(self):
+        result = format_task_as_todo_txt(
+            make_task(is_completed=True, completed_at="2023-01-20T00:00:00Z", priority=4), ""
+        )
+        assert result.startswith("x 2023-01-20 (A)")
+
+    def test_client_emitted_as_key_value(self):
+        result = format_task_as_todo_txt(make_task(), "Work", client="ACME")
+        assert "client:ACME" in result
+
+    def test_empty_client_omitted(self):
+        result = format_task_as_todo_txt(make_task(), "Work", client="")
+        assert "client:" not in result
+
+    def test_client_comes_after_due_date(self):
+        result = format_task_as_todo_txt(
+            make_task(due={"date": "2023-02-01"}), "Work", client="ACME"
+        )
+        assert result.index("due:") < result.index("client:")


### PR DESCRIPTION
Adds taskbridge export todo-txt and taskbridge config todo-txt commands. When a todo_txt_path is configured, the file is regenerated automatically after task done, sync notes, sync projects, and sync jira.

Tasks are formatted per the todo.txt spec with priority, creation date, +Project, @label, due:, and client: extension fields. Client and folder names are sourced from the configured project mappings. Completed tasks get an x YYYY-MM-DD prefix. Writes are atomic (tmp file + rename).